### PR TITLE
Change version from 0.1.0 to 0.2.0 of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ ecs-helper
 
 ## Latest version
 
-- `v0.1.0`
-  - (Download (for macOS))[https://github.com/hajimeni/ecs-helper/releases/download/v0.1.0/ecs-helper-darwin-amd64.tar.gz]
-  - (Download (for Linux))[https://github.com/hajimeni/ecs-helper/releases/download/v0.1.0/ecs-helper-linux-amd64.tar.gz]
+- `v0.2.0`
+  - (Download (for macOS))[https://github.com/hajimeni/ecs-helper/releases/download/v0.2.0/ecs-helper-darwin-amd64.tar.gz]
+  - (Download (for Linux))[https://github.com/hajimeni/ecs-helper/releases/download/v0.2.0/ecs-helper-linux-amd64.tar.gz]
 
 ## Usage
 


### PR DESCRIPTION
ecs-helperの最新版は0.2.0ですが、READMEのlatestが0.1.0となっていたため、正しく修正しました。