### PR TITLE
add secret parameter

### DIFF
--- a/src/ecs-helper/config/ecs-params.go
+++ b/src/ecs-helper/config/ecs-params.go
@@ -38,5 +38,10 @@ type ServiceConfig struct {
     CpuShares int `yaml:"cpu_shares,omitempty"`
     MemLimit int `yaml:"mem_limit,omitempty"`
     MemReservation int `yaml:"mem_reservation,omitempty"`
+    Secrets []SecretsConfig `yaml:"secrets,omitempty"`
 }
 
+type SecretsConfig struct {
+    ValueFrom string `yaml:"value_from,omitempty"`
+    Value string `yaml:"name,omitempty"`
+}


### PR DESCRIPTION
AWS Launches Secrets Support for Amazon Elastic Container Service
https://aws.amazon.com/jp/about-aws/whats-new/2018/11/aws-launches-secrets-support-for-amazon-elastic-container-servic/

secret parameter 
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cmd-ecs-cli-compose-ecsparams.html